### PR TITLE
Updates to work with current Auth0 and Grails 3.3.2 (latest Grails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ grails --version
 FYI only, in creating this sample, the following SDK versions were used:
 
  ```
-Grails Version: 3.1.9
-Groovy Version: 2.4.7
+Grails Version: 3.3.2
+Groovy Version: 2.4.13
 JVM Version: 1.8.0_77
  ```
 
@@ -40,7 +40,9 @@ Create an [Auth0 Account](https://auth0.com) (if not already done so - free!).
 
 #### From the Auth0 Dashboard
 
-Create an application - for the purposes of this sample - `app`
+Create a client - for the purposes of this sample - `app`
+
+##### In the client's "settings" tab:
 
 Ensure you add the following to the settings.
 
@@ -61,6 +63,12 @@ http://localhost:3099/logout
 Add one or more `connections` to your application - for instance Google Social Connection,
 or username-password DB connection.
 
+##### In "Advanced Settings"
+
+Under the OAuth tab, change the JsonWebToken Signature Algorithm to HS256.
+
+Alternatively, download the certificate available in the Certificates tab and make appropriate changes to your
+auth0.properties file to use the certificate and the default RS256 signature algorithm.
 
 ###### Add Role Based Authorization By Creating an Auth0 Rule
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.8.2"
+        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.14.2"
         classpath "org.grails.plugins:hibernate4:5.0.10"
     }
 }
@@ -34,7 +34,7 @@ dependencyManagement {
 
 dependencies {
     compile "org.grails.plugins:cache"
-    compile "org.grails.plugins:hibernate4"
+    compile "org.grails.plugins:hibernate5"
     compile "org.grails.plugins:scaffolding"
     compile "org.grails:grails-core"
     compile "org.grails:grails-dependencies"
@@ -45,12 +45,13 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-logging"
     compile "org.springframework.boot:spring-boot-starter-tomcat"
     compile 'com.auth0:mvc-auth-commons:0.1.1'
-    compile 'com.auth0:auth0-spring-security-mvc:1.2.3'
+    compile 'com.auth0:auth0-spring-security-mvc:1.3.0'
+    /* compile 'com.auth0:mvc-auth-commons:1.+' */
     compile 'javax.servlet:jstl:1.2'
     compile 'org.springframework.boot:spring-boot-starter-security'
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
-    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.8.2"
+    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.2"
     runtime "com.h2database:h2"
     testCompile "org.grails.plugins:geb"
     testCompile "org.grails:grails-plugin-testing"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.1.9
+grailsVersion=3.3.2
 gradleWrapperVersion=2.13

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -1,7 +1,7 @@
 ---
 
 server:
-  port: 3099
+  port: 8080
 
 hibernate:
     cache:

--- a/grails-app/controllers/auth0/grails3/mvc/sample/HomeController.groovy
+++ b/grails-app/controllers/auth0/grails3/mvc/sample/HomeController.groovy
@@ -5,9 +5,11 @@ import com.auth0.example.AdminService
 import com.auth0.spring.security.mvc.Auth0UserDetails
 import com.auth0.Auth0User
 import com.auth0.spring.security.mvc.Auth0Config
+import groovy.util.logging.Log4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.core.context.SecurityContextHolder
 
+@Log4j
 class HomeController {
 
     static defaultAction = "home"

--- a/grails-app/controllers/auth0/grails3/mvc/sample/LoginController.groovy
+++ b/grails-app/controllers/auth0/grails3/mvc/sample/LoginController.groovy
@@ -3,8 +3,10 @@ package auth0.grails3.mvc.sample
 import com.auth0.spring.security.mvc.Auth0Config
 import com.auth0.NonceUtils
 import com.auth0.SessionUtils
+import groovy.util.logging.Log4j
 import org.springframework.beans.factory.annotation.Autowired
 
+@Log4j
 class LoginController {
 
     static defaultAction = "login"

--- a/grails-app/controllers/auth0/grails3/mvc/sample/LogoutController.groovy
+++ b/grails-app/controllers/auth0/grails3/mvc/sample/LogoutController.groovy
@@ -1,8 +1,10 @@
 package auth0.grails3.mvc.sample
 
 import com.auth0.spring.security.mvc.Auth0Config
+import groovy.util.logging.Log4j
 import org.springframework.beans.factory.annotation.Autowired
 
+@Log4j
 class LogoutController {
 
     static defaultAction = "logout"


### PR DESCRIPTION
Howdy,

I cloned this today to try out Auth0 and found it wasn't working with:

1. The current client JWT defaults from Auth0 (default: RS, this repo: HS)
2. Grails 3.3.2

This pull request fixes that and updates the documentation to match.